### PR TITLE
Fix: Ensure custom message is returned when defaultMessage is false

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,9 +47,12 @@ const {
   ServiceUnavailable,
   GatewayTimeout,
   HttpVersionNotSupported,
+  sendResponse,
 } = require("./responses");
+const { HttpStatus, HttpStatusMessages } = require("./statusCodes");
 
 module.exports = {
+  sendResponse,
   Continue,
   SwitchingProtocols,
   Processing,
@@ -98,4 +101,6 @@ module.exports = {
   ServiceUnavailable,
   GatewayTimeout,
   HttpVersionNotSupported,
+  HttpStatus,
+  HttpStatusMessages,
 };

--- a/src/responses.js
+++ b/src/responses.js
@@ -9,156 +9,395 @@ const sendResponse = (
 ) => {
   const responseObject = {
     statusCode,
-    ...(defaultMessage && {
-      message: customMessage || HttpStatusMessages[statusCode],
-    }),
+    ...(customMessage
+      ? { message: customMessage }
+      : defaultMessage && { message: HttpStatusMessages[statusCode] }),
     ...data,
   };
   res.status(statusCode).json(responseObject);
 };
 
-const Continue = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.CONTINUE, res, message, data);
+const Continue = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.CONTINUE, res, message, data, defaultMessage);
 
-const SwitchingProtocols = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.SWITCHING_PROTOCOLS, res, message, data);
+const SwitchingProtocols = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.SWITCHING_PROTOCOLS,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const Processing = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.PROCESSING, res, message, data);
+const Processing = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.PROCESSING, res, message, data, defaultMessage);
 
-const EarlyHints = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.EARLY_HINTS, res, message, data);
+const EarlyHints = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.EARLY_HINTS, res, message, data, defaultMessage);
 
-const Ok = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.OK, res, message, data);
+const Ok = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.OK, res, message, data, defaultMessage);
 
-const Created = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.CREATED, res, message, data);
+const Created = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.CREATED, res, message, data, defaultMessage);
 
-const Accepted = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.ACCEPTED, res, message, data);
+const Accepted = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.ACCEPTED, res, message, data, defaultMessage);
 
-const NonAuthoritativeInformation = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.NON_AUTHORITATIVE_INFORMATION, res, message, data);
+const NonAuthoritativeInformation = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.NON_AUTHORITATIVE_INFORMATION,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
 const NoContent = (res) => res.status(HttpStatus.NO_CONTENT).end();
 
-const ResetContent = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.RESET_CONTENT, res, message, data);
+const ResetContent = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.RESET_CONTENT, res, message, data, defaultMessage);
 
-const PartialContent = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.PARTIAL_CONTENT, res, message, data);
+const PartialContent = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(HttpStatus.PARTIAL_CONTENT, res, message, data, defaultMessage);
 
-const Ambiguous = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.AMBIGUOUS, res, message, data);
+const Ambiguous = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.AMBIGUOUS, res, message, data, defaultMessage);
 
-const MovedPermanently = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.MOVED_PERMANENTLY, res, message, data);
+const MovedPermanently = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.MOVED_PERMANENTLY,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const Found = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.FOUND, res, message, data);
+const Found = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.FOUND, res, message, data, defaultMessage);
 
-const SeeOther = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.SEE_OTHER, res, message, data);
+const SeeOther = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.SEE_OTHER, res, message, data, defaultMessage);
 
-const NotModified = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.NOT_MODIFIED, res, message, data);
+const NotModified = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.NOT_MODIFIED, res, message, data, defaultMessage);
 
-const TemporaryRedirect = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.TEMPORARY_REDIRECT, res, message, data);
+const TemporaryRedirect = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.TEMPORARY_REDIRECT,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const PermanentRedirect = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.PERMANENT_REDIRECT, res, message, data);
+const PermanentRedirect = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.PERMANENT_REDIRECT,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const BadRequest = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.BAD_REQUEST, res, message, data);
+const BadRequest = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.BAD_REQUEST, res, message, data, defaultMessage);
 
-const Unauthorized = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.UNAUTHORIZED, res, message, data);
+const Unauthorized = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.UNAUTHORIZED, res, message, data, defaultMessage);
 
-const PaymentRequired = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.PAYMENT_REQUIRED, res, message, data);
+const PaymentRequired = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(HttpStatus.PAYMENT_REQUIRED, res, message, data, defaultMessage);
 
-const Forbidden = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.FORBIDDEN, res, message, data);
+const Forbidden = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.FORBIDDEN, res, message, data, defaultMessage);
 
-const NotFound = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.NOT_FOUND, res, message, data);
+const NotFound = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.NOT_FOUND, res, message, data, defaultMessage);
 
-const MethodNotAllowed = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.METHOD_NOT_ALLOWED, res, message, data);
+const MethodNotAllowed = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.METHOD_NOT_ALLOWED,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const NotAcceptable = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.NOT_ACCEPTABLE, res, message, data);
+const NotAcceptable = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.NOT_ACCEPTABLE, res, message, data, defaultMessage);
 
-const ProxyAuthenticationRequired = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.PROXY_AUTHENTICATION_REQUIRED, res, message, data);
+const ProxyAuthenticationRequired = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.PROXY_AUTHENTICATION_REQUIRED,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const RequestTimeout = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.REQUEST_TIMEOUT, res, message, data);
+const RequestTimeout = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(HttpStatus.REQUEST_TIMEOUT, res, message, data, defaultMessage);
 
-const Conflict = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.CONFLICT, res, message, data);
+const Conflict = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.CONFLICT, res, message, data, defaultMessage);
 
-const Gone = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.GONE, res, message, data);
+const Gone = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.GONE, res, message, data, defaultMessage);
 
-const LengthRequired = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.LENGTH_REQUIRED, res, message, data);
+const LengthRequired = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(HttpStatus.LENGTH_REQUIRED, res, message, data, defaultMessage);
 
-const PreconditionFailed = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.PRECONDITION_FAILED, res, message, data);
+const PreconditionFailed = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.PRECONDITION_FAILED,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const PayloadTooLarge = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.PAYLOAD_TOO_LARGE, res, message, data);
+const PayloadTooLarge = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.PAYLOAD_TOO_LARGE,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const UriTooLong = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.URI_TOO_LONG, res, message, data);
+const UriTooLong = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.URI_TOO_LONG, res, message, data, defaultMessage);
 
-const UnsupportedMediaType = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.UNSUPPORTED_MEDIA_TYPE, res, message, data);
+const UnsupportedMediaType = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const RequestedRangeNotSatisfiable = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE, res, message, data);
+const RequestedRangeNotSatisfiable = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const ExpectationFailed = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.EXPECTATION_FAILED, res, message, data);
+const ExpectationFailed = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.EXPECTATION_FAILED,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const IAmATeapot = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.I_AM_A_TEAPOT, res, message, data);
+const IAmATeapot = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.I_AM_A_TEAPOT, res, message, data, defaultMessage);
 
-const Misdirected = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.MISDIRECTED, res, message, data);
+const Misdirected = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.MISDIRECTED, res, message, data, defaultMessage);
 
-const UnprocessableEntity = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.UNPROCESSABLE_ENTITY, res, message, data);
+const UnprocessableEntity = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.UNPROCESSABLE_ENTITY,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const FailedDependency = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.FAILED_DEPENDENCY, res, message, data);
+const FailedDependency = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.FAILED_DEPENDENCY,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const PreconditionRequired = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.PRECONDITION_REQUIRED, res, message, data);
+const PreconditionRequired = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.PRECONDITION_REQUIRED,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const TooManyRequests = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.TOO_MANY_REQUESTS, res, message, data);
+const TooManyRequests = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.TOO_MANY_REQUESTS,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const InternalServerError = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.INTERNAL_SERVER_ERROR, res, message, data);
+const InternalServerError = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.INTERNAL_SERVER_ERROR,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const NotImplemented = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.NOT_IMPLEMENTED, res, message, data);
+const NotImplemented = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(HttpStatus.NOT_IMPLEMENTED, res, message, data, defaultMessage);
 
-const BadGateway = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.BAD_GATEWAY, res, message, data);
+const BadGateway = (res, message = null, data = {}, defaultMessage = true) =>
+  sendResponse(HttpStatus.BAD_GATEWAY, res, message, data, defaultMessage);
 
-const ServiceUnavailable = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.SERVICE_UNAVAILABLE, res, message, data);
+const ServiceUnavailable = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.SERVICE_UNAVAILABLE,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
-const GatewayTimeout = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.GATEWAY_TIMEOUT, res, message, data);
+const GatewayTimeout = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(HttpStatus.GATEWAY_TIMEOUT, res, message, data, defaultMessage);
 
-const HttpVersionNotSupported = (res, message = null, data = {}) =>
-  sendResponse(HttpStatus.HTTP_VERSION_NOT_SUPPORTED, res, message, data);
+const HttpVersionNotSupported = (
+  res,
+  message = null,
+  data = {},
+  defaultMessage = true
+) =>
+  sendResponse(
+    HttpStatus.HTTP_VERSION_NOT_SUPPORTED,
+    res,
+    message,
+    data,
+    defaultMessage
+  );
 
 module.exports = {
   Continue,

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -47,6 +47,8 @@ const {
   ServiceUnavailable,
   GatewayTimeout,
   HttpVersionNotSupported,
+  sendResponse,
+  HttpStatus,
 } = require("../src/index");
 
 let res;
@@ -486,6 +488,70 @@ describe("HTTP Status Response Functions", () => {
     expect(res.json).toHaveBeenCalledWith({
       statusCode: 203,
       message: "Non-authoritative information",
+    });
+  });
+});
+
+describe("sendResponse", () => {
+  test("sends response with status code and default message", () => {
+    sendResponse(HttpStatus.OK, res);
+    expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+    expect(res.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.OK,
+      message: "OK",
+    });
+  });
+
+  test("sends response with custom message", () => {
+    const customMessage = "Custom OK message";
+    sendResponse(HttpStatus.OK, res, customMessage);
+    expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+    expect(res.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.OK,
+      message: customMessage,
+    });
+  });
+
+  test("sends response with additional data", () => {
+    const data = { key: "value" };
+    sendResponse(HttpStatus.OK, res, null, data);
+    expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+    expect(res.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.OK,
+      message: "OK",
+      key: "value",
+    });
+  });
+
+  test("sends response without message when defaultMessage is false", () => {
+    sendResponse(HttpStatus.OK, res, null, {}, false);
+    expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+    expect(res.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.OK,
+    });
+  });
+
+  test("sends response with custom message when defaultMessage is false", () => {
+    const customMessage = "Custom message";
+    sendResponse(HttpStatus.OK, res, customMessage, {}, false);
+
+    console.log("Res", res);
+    expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+    expect(res.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.OK,
+      message: customMessage,
+    });
+  });
+
+  test("sends response with custom message, data, and defaultMessage true", () => {
+    const customMessage = "Custom OK message";
+    const data = { key: "value" };
+    sendResponse(HttpStatus.OK, res, customMessage, data, true);
+    expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+    expect(res.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.OK,
+      message: customMessage,
+      key: "value",
     });
   });
 });


### PR DESCRIPTION
### Description
This pull request fixes a bug where the `sendResponse` function did not include the custom message when `defaultMessage` was set to `false`. The issue occurred because the custom message was not prioritized in this case, and only the default message flag was being checked.

### Changes
- Updated `sendResponse` to ensure the custom message is always included, regardless of the `defaultMessage` flag.
- This ensures that if a custom message is provided, it will be returned even when `defaultMessage` is `false`.

### Testing
- Updated unit tests to cover the scenario where a custom message is passed, and `defaultMessage` is set to `false`.
